### PR TITLE
Added Pagination for search results

### DIFF
--- a/Django/ffs/templates/landing-page.html
+++ b/Django/ffs/templates/landing-page.html
@@ -144,7 +144,7 @@
           </div>
           <div class="col-md-10 col-lg-8 col-xl-7 mx-auto">
           <div class="m-0 text-center">
-              <button type="submit" class="btn btn-block btn-lg btn-primary">Sign up!</button>
+              <a href="/signup" class="btn btn-block btn-lg btn-primary">Sign up!</a>
           </div>
           </div>
         </div>

--- a/Django/ffs/templates/search_result_page.html
+++ b/Django/ffs/templates/search_result_page.html
@@ -66,7 +66,7 @@
 
       <!-- Pagination -->
       <ul class="pagination justify-content-center">
-        {% if currPage > pages|length %}
+        {% if currPage > 1 %}
         <li class="page-item">
           <a class="page-link" href="#" onclick="setGetParameter('page', '{{ currPage|add:'-1' }}')" aria-label="Previous">
             <span aria-hidden="true">&laquo;</span>

--- a/Django/ffs/templates/search_result_page.html
+++ b/Django/ffs/templates/search_result_page.html
@@ -66,30 +66,33 @@
 
       <!-- Pagination -->
       <ul class="pagination justify-content-center">
+        {% if currPage > pages|length %}
         <li class="page-item">
-          <a class="page-link" href="#" aria-label="Previous">
+          <a class="page-link" href="#" onclick="setGetParameter('page', '{{ currPage|add:'-1' }}')" aria-label="Previous">
             <span aria-hidden="true">&laquo;</span>
             <span class="sr-only">Previous</span>
           </a>
         </li>
+        {% endif %}
+        {% for n in pages %}
+          {% if n == currPage %}
+            <li class="page-item active">
+              <a class="page-link" href="#" onclick="setGetParameter('page', '{{ n }}')">{{ n }}</a>
+            </li>
+          {% else %}
+            <li class="page-item">
+              <a class="page-link" href="#" onclick="setGetParameter('page', '{{ n }}')">{{ n }}</a>
+            </li>
+          {% endif %}
+        {% endfor %}
+        {% if currPage < pages|length %}
         <li class="page-item">
-          <a class="page-link" href="#">1</a>
-        </li>
-        <li class="page-item">
-          <a class="page-link" href="#">2</a>
-        </li>
-        <li class="page-item">
-          <a class="page-link" href="#">3</a>
-        </li>
-        <li class="page-item">
-          <a class="page-link" href="#">4</a>
-        </li>
-        <li class="page-item">
-          <a class="page-link" href="#" aria-label="Next">
+          <a class="page-link" href="#" onclick="setGetParameter('page', '{{ currPage|add:'1' }}')" aria-label="Next">
             <span aria-hidden="true">&raquo;</span>
             <span class="sr-only">Next</span>
           </a>
         </li>
+        {% endif %}
       </ul>
     </div>
   </div>
@@ -107,4 +110,28 @@
 
 {% block footer %}
 <footer id="foot" class="py-5 bg-dark" style="position:static;bottom:0;width:100%">
+<script>
+function setGetParameter(paramName, paramValue)
+  {
+      var url = window.location.href;
+      var hash = location.hash;
+      url = url.replace(hash, '');
+      if (url.indexOf(paramName + "=") >= 0)
+      {
+          var prefix = url.substring(0, url.indexOf(paramName));
+          var suffix = url.substring(url.indexOf(paramName));
+          suffix = suffix.substring(suffix.indexOf("=") + 1);
+          suffix = (suffix.indexOf("&") >= 0) ? suffix.substring(suffix.indexOf("&")) : "";
+          url = prefix + paramName + "=" + paramValue + suffix;
+      }
+      else
+      {
+      if (url.indexOf("?") < 0)
+          url += "?" + paramName + "=" + paramValue;
+      else
+          url += "&" + paramName + "=" + paramValue;
+      }
+      window.location.href = url + hash;
+  }
+</script>
 {% endblock %}

--- a/Django/ffs/views.py
+++ b/Django/ffs/views.py
@@ -19,7 +19,7 @@ def search_view(request):
 	currPage = int(currPage)
 	queryset = Product.objects.filter(title__icontains=query)
 	pages = (((len(queryset) - (len(queryset) % settings.MAX_PAGE_ITEMS)) / settings.MAX_PAGE_ITEMS) + 1) if (len(queryset) > settings.MAX_PAGE_ITEMS) else 1
-	pages = range(1, int(pages)+1)
+	pages = range(1, int(pages))
 	queryset = queryset[currPage * settings.MAX_PAGE_ITEMS:((currPage * settings.MAX_PAGE_ITEMS)+settings.MAX_PAGE_ITEMS) if (((currPage * settings.MAX_PAGE_ITEMS)+settings.MAX_PAGE_ITEMS) < len(queryset)) else len(queryset)]
 	context = { 'results': queryset, 'entered_text': query, 'pages': pages, 'currPage': currPage}
 	return render(request, 'search_result_page.html', context)

--- a/Django/ffs/views.py
+++ b/Django/ffs/views.py
@@ -19,8 +19,8 @@ def search_view(request):
 	currPage = int(currPage)
 	queryset = Product.objects.filter(title__icontains=query)
 	pages = (((len(queryset) - (len(queryset) % settings.MAX_PAGE_ITEMS)) / settings.MAX_PAGE_ITEMS) + 1) if (len(queryset) > settings.MAX_PAGE_ITEMS) else 1
-	pages = range(1, int(pages))
-	queryset = queryset[currPage * settings.MAX_PAGE_ITEMS:((currPage * settings.MAX_PAGE_ITEMS)+settings.MAX_PAGE_ITEMS) if (((currPage * settings.MAX_PAGE_ITEMS)+settings.MAX_PAGE_ITEMS) < len(queryset)) else len(queryset)]
+	pages = range(1, int(pages) + 1)
+	queryset = queryset[(currPage - 1) * settings.MAX_PAGE_ITEMS:((currPage * settings.MAX_PAGE_ITEMS)) if (((currPage * settings.MAX_PAGE_ITEMS)+settings.MAX_PAGE_ITEMS) < len(queryset)) else len(queryset)]
 	context = { 'results': queryset, 'entered_text': query, 'pages': pages, 'currPage': currPage}
 	return render(request, 'search_result_page.html', context)
 

--- a/Django/ffs/views.py
+++ b/Django/ffs/views.py
@@ -15,8 +15,13 @@ def landing_view(request):
 
 def search_view(request):
 	query = request.GET.get("q")
+	currPage = request.GET.get("page", 1)
+	currPage = int(currPage)
 	queryset = Product.objects.filter(title__icontains=query)
-	context = { 'results': queryset, 'entered_text': query }
+	pages = (((len(queryset) - (len(queryset) % settings.MAX_PAGE_ITEMS)) / settings.MAX_PAGE_ITEMS) + 1) if (len(queryset) > settings.MAX_PAGE_ITEMS) else 1
+	pages = range(1, int(pages)+1)
+	queryset = queryset[currPage * settings.MAX_PAGE_ITEMS:((currPage * settings.MAX_PAGE_ITEMS)+settings.MAX_PAGE_ITEMS) if (((currPage * settings.MAX_PAGE_ITEMS)+settings.MAX_PAGE_ITEMS) < len(queryset)) else len(queryset)]
+	context = { 'results': queryset, 'entered_text': query, 'pages': pages, 'currPage': currPage}
 	return render(request, 'search_result_page.html', context)
 
 @login_required(login_url="/accounts/login/")

--- a/Django/universale/settings.py
+++ b/Django/universale/settings.py
@@ -130,9 +130,19 @@ MEDIA_ROOT = os.path.join(os.path.dirname(BASE_DIR), "static_cdn", "media_root")
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/accounts/login'
 
+# Image types permitted into the upload system
+
 ALLOWED_IMAGE_TYPES = [
     ".jpg",
     ".jpeg",
     ".png",
     ".gif"
 ]
+
+# Pagination options
+
+MAX_PAGE_ITEMS = 3
+
+# Max size is on either side. Odds only with output, which is prettier anyways
+
+MAX_PAGINATOR_SIZE = 2


### PR DESCRIPTION
## Description
Added functioning pagination to the search page with highlighting for current page, page forwards and back support etc, etc. MAX_PAGE_ITEMS in universale/settings.py sets how many items on a page. I recommend my setting of 3 but it's totally up to @vedantpuri 

## Related Issue
[#28](https://github.com/vedantpuri/universale/issues/28) Pagination is mentioned here and is solved, at least in search.

## How Has This Been Tested?
Extensively navigated menus, however due to [no testing mechanism](https://github.com/vedantpuri/universale/issues/39) yet I couldn't see how it reacts to less than MAX_PAGE_ITEMS items in the Query set. However I believe my code should handle this well

## Context (Environment)
Chrome (Latest), Firefox (Quantum, Latest), Opera (Latest), No IE/Edge because linux.

## Screenshots (if appropriate):
![selection_007](https://user-images.githubusercontent.com/15064194/43176090-dd5babec-8f87-11e8-96f2-0789044eb64b.png)
![selection_008](https://user-images.githubusercontent.com/15064194/43176092-e03f127c-8f87-11e8-8f20-2c7ccd5c9df5.png)
![selection_009](https://user-images.githubusercontent.com/15064194/43176097-e246897e-8f87-11e8-94c5-41d73230da5a.png)

Have a good one :smile: 